### PR TITLE
Add login page and auth context

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import Charities from "./pages/Charities";
 import Mission  from "./pages/Mission";
 import ToolShed from "./pages/ToolShed";
 import WeeklyBlog from "./pages/WeeklyBlog";
+import Login from "./pages/Login";
 
 export default function App() {
   return (
@@ -30,8 +31,9 @@ export default function App() {
         <Route path="/story"     element={<Story />} />
         <Route path="/charities" element={<Charities />} />
         <Route path="/mission"   element={<Mission />} />
-	<Route path="/toolshed" element={<ToolShed />} />
-	<Route path="/weeklyblog" element={<WeeklyBlog />} />
+        <Route path="/toolshed" element={<ToolShed />} />
+        <Route path="/weeklyblog" element={<WeeklyBlog />} />
+        <Route path="/login"    element={<Login />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,28 @@
+/* eslint react-refresh/only-export-components: off */
+import React, { createContext, useContext, useState } from "react";
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  const login = ({ username, password }) => {
+    if (username === "admin" && password === "password123") {
+      setIsAuthenticated(true);
+      return true;
+    }
+    return false;
+  };
+
+  const logout = () => setIsAuthenticated(false);
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { AuthProvider } from './contexts/AuthContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Layout from "../Layout";
+import { useAuth } from "../contexts/AuthContext";
+
+export default function Login() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const success = login({ username, password });
+    if (success) {
+      navigate("/");
+    } else {
+      setError("Invalid credentials");
+    }
+  };
+
+  return (
+    <Layout className="p-8 text-black">
+      <h2 className="text-2xl font-bold mb-4">Login</h2>
+      <form onSubmit={handleSubmit} className="flex flex-col space-y-4 max-w-xs">
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="p-2 border border-gray-300 rounded"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="p-2 border border-gray-300 rounded"
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+          Login
+        </button>
+      </form>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- create `AuthContext` to manage authentication state
- add a new `Login` page
- wrap app in `AuthProvider`
- define a simple admin credential and new login route

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68657df470c08325835632c3d0bcee09