### PR TITLE
Fix AuthContext import path

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Layout from "../Layout";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "../contexts/AuthContext.jsx";
 
 export default function Login() {
   const { login } = useAuth();


### PR DESCRIPTION
## Summary
- fix Login page to include `.jsx` for AuthContext

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866929968d483259bc94e5c61787189