### PR TITLE
feat: logout button in layout

### DIFF
--- a/src/Layout.jsx
+++ b/src/Layout.jsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useAuth } from "./contexts/AuthContext";
 
 export default function Layout({ children, className = "", style = {} }) {
+  const { isAuthenticated, logout } = useAuth();
   return (
     <div
       className={
@@ -9,6 +11,16 @@ export default function Layout({ children, className = "", style = {} }) {
       }
       style={{ backgroundImage: "url('/bg.png')", ...style }}
     >
+      {isAuthenticated && (
+        <div className="absolute top-4 right-4">
+          <button
+            onClick={logout}
+            className="px-4 py-2 bg-red-600 text-white rounded"
+          >
+            Logout
+          </button>
+        </div>
+      )}
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- add auth hook usage inside `Layout`
- render a logout button when logged in

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686692a17e9c8325ad05fac831a2e055