### PR TITLE
Add responsive Tailwind styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@tailwindcss/postcss": "^4.1.11",
+        "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.11",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -1612,6 +1613,22 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.11.tgz",
@@ -1993,6 +2010,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -2892,6 +2922,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3160,6 +3204,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -3504,6 +3562,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@tailwindcss/postcss": "^4.1.11",
+    "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.11",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/src/Layout.jsx
+++ b/src/Layout.jsx
@@ -6,7 +6,7 @@ export default function Layout({ children, className = "", style = {} }) {
   return (
     <div
       className={
-        "min-h-screen flex flex-col items-center justify-center bg-cover bg-center " +
+        "min-h-screen relative flex flex-col items-center justify-center bg-cover bg-center " +
         className
       }
       style={{ backgroundImage: "url('/bg.png')", ...style }}
@@ -21,7 +21,7 @@ export default function Layout({ children, className = "", style = {} }) {
           </button>
         </div>
       )}
-      {children}
+      <div className="container mx-auto w-full p-4 sm:p-8">{children}</div>
     </div>
   );
 }

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -5,7 +5,7 @@ import Layout from "../Layout";
 export default function About() {
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-4">About Us</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-4">About Us</h2>
       <p className="mb-6 max-w-2xl">
         Savage Nation USA was founded to bring the fiercest, most unapologetic patriotic gear to the world.
       </p>

--- a/src/pages/BlogAdmin.jsx
+++ b/src/pages/BlogAdmin.jsx
@@ -40,7 +40,7 @@ export default function BlogAdmin() {
 
   return (
     <Layout className="p-8 text-black overflow-y-auto" style={{ minHeight: "100vh" }}>
-      <h2 className="text-3xl font-bold mb-4">Blog Admin</h2>
+      <h2 className="text-2xl sm:text-3xl font-bold mb-4">Blog Admin</h2>
       <form onSubmit={handleSubmit} className="space-y-3 mb-6 max-w-md">
         <input
           name="title"

--- a/src/pages/Charities.jsx
+++ b/src/pages/Charities.jsx
@@ -5,7 +5,7 @@ import Layout from "../Layout";
 export default function Charities() {
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-4">Our Supported Charities</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-4">Our Supported Charities</h2>
       <ul className="list-disc list-inside mb-6 max-w-2xl">
         <li>Charity A – Supports veterans and their families.</li>
         <li>Charity B – Provides tactical gear to first responders.</li>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -13,7 +13,7 @@ export default function Contact() {
 
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-4">Contact Us</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-4">Contact Us</h2>
       <form onSubmit={handleSubmit} className="max-w-lg space-y-4">
         <input name="name" value={form.name} onChange={handleChange} placeholder="Name"
                className="w-full px-4 py-2 border rounded" required />

--- a/src/pages/EditBlog.jsx
+++ b/src/pages/EditBlog.jsx
@@ -42,7 +42,7 @@ export default function EditBlog() {
 
   return (
     <Layout className="p-8 text-black overflow-y-auto" style={{ minHeight: "100vh" }}>
-      <h2 className="text-3xl font-bold mb-4">Edit Blog</h2>
+      <h2 className="text-2xl sm:text-3xl font-bold mb-4">Edit Blog</h2>
       <form onSubmit={handleSubmit} className="space-y-3 mb-6 max-w-md">
         <input
           name="title"

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -11,7 +11,7 @@ const faqItems = [
 export default function FAQ() {
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-6">FAQ</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-6">FAQ</h2>
       <div className="space-y-4 max-w-2xl">
         {faqItems.map((item, i) => (
           <div key={i}>

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -11,7 +11,7 @@ const galleryItems = [
 export default function Gallery() {
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-6">Gallery</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-6">Gallery</h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {galleryItems.map((item, i) => (
           <div key={i} className="border rounded-lg p-4 shadow">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,10 +5,10 @@ import Layout from "../Layout";
 export default function Home() {
   return (
     <Layout className="text-white">
-      <h1 className="text-5xl font-extrabold text-center">
+      <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-center">
         Savage Nation USA
       </h1>
-      <p className="mt-4 text-lg font-semibold text-red-500 uppercase text-center">
+      <p className="mt-4 text-base sm:text-lg font-semibold text-red-500 uppercase text-center">
         ONLY ENTER IF YOU&apos;RE SAVAGE ENOUGH
       </p>
       <Link to="/landing">

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -21,9 +21,9 @@ export default function Landing() {
   };
 
   return (
-    <div className="min-h-screen flex bg-[url('/bg.png')] bg-cover bg-center text-white">
-      <aside className="w-64 bg-black bg-opacity-70 p-6">
-        <h3 className="text-2xl font-bold mb-4">Navigation</h3>
+    <div className="min-h-screen flex flex-col sm:flex-row bg-[url('/bg.png')] bg-cover bg-center text-white">
+      <aside className="w-full sm:w-64 bg-black bg-opacity-70 p-6">
+        <h3 className="text-xl sm:text-2xl font-bold mb-4">Navigation</h3>
         <nav className="flex flex-col space-y-2">
           {pages.map((p) => {
             const key = typeof p === "object" ? p.key : p;
@@ -42,15 +42,15 @@ export default function Landing() {
           })}
         </nav>
       </aside>
-      <main className="flex-1 p-10">
-        <h2 className="text-4xl font-bold mb-6 text-white">Welcome to Savage Nation USA</h2>
+      <main className="flex-1 p-6 sm:p-10 overflow-y-auto">
+        <h2 className="text-3xl sm:text-4xl font-bold mb-6 text-white">Welcome to Savage Nation USA</h2>
         <input
           type="text"
           placeholder="Search pages..."
           value={navTerm}
           onChange={(e) => setNavTerm(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleNav(navTerm)}
-          className="w-full max-w-md px-4 py-2 mb-8 rounded bg-white/30 text-black"
+          className="w-full max-w-md px-4 py-2 mb-8 rounded bg-white/30 text-black placeholder-black/50"
         />
         <p>Use the sidebar to navigate.</p>
       </main>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -22,7 +22,7 @@ export default function Login() {
 
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-2xl font-bold mb-4">Login</h2>
+      <h2 className="text-xl sm:text-2xl font-bold mb-4">Login</h2>
       <form onSubmit={handleSubmit} className="flex flex-col space-y-4 max-w-xs">
         <input
           type="text"

--- a/src/pages/Mission.jsx
+++ b/src/pages/Mission.jsx
@@ -5,7 +5,7 @@ import Layout from "../Layout";
 export default function Mission() {
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-4">Our Mission & Promise</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-4">Our Mission & Promise</h2>
       <p className="mb-6 max-w-2xl">
         [Describe your mission and promise here—what Savage Nation USA stands for, and the guarantees you make to your customers.]
       </p>

--- a/src/pages/Store.jsx
+++ b/src/pages/Store.jsx
@@ -15,9 +15,9 @@ export default function Store() {
   );
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-4">Our Store</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-4">Our Store</h2>
       <input
-        className="mb-6 px-4 py-2 border rounded w-full max-w-md"
+        className="mb-6 px-4 py-2 border rounded w-full max-w-md placeholder-black/50"
         type="text"
         placeholder="Search products..."
         value={searchTerm}
@@ -25,13 +25,13 @@ export default function Store() {
       />
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {filtered.map(item => (
-          <div key={item.name} className="border rounded-lg p-4 shadow">
+          <div key={item.name} className="bg-white border rounded-lg p-4 shadow-lg flex flex-col">
             <div className="h-40 bg-gray-200 mb-4 flex items-center justify-center">
               <span className="text-gray-500">Image</span>
             </div>
-            <h3 className="text-xl font-semibold mb-2">{item.name}</h3>
-            <p className="mb-4">{item.price}</p>
-            <button className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded">
+            <h3 className="text-lg font-semibold mb-2 text-center">{item.name}</h3>
+            <p className="mb-4 text-center">{item.price}</p>
+            <button className="mt-auto px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded">
               Buy Now
             </button>
           </div>

--- a/src/pages/Story.jsx
+++ b/src/pages/Story.jsx
@@ -5,7 +5,7 @@ import Layout from "../Layout";
 export default function Story() {
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-4">Our Story</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-4">Our Story</h2>
       <p className="mb-6 max-w-2xl">
         [Your brand’s story goes here—how Savage Nation USA came to be, your mission, and your journey.]
       </p>

--- a/src/pages/ToolShed.jsx
+++ b/src/pages/ToolShed.jsx
@@ -5,7 +5,7 @@ import Layout from "../Layout";
 export default function ToolShed() {
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-4">Tool Shed</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-4">Tool Shed</h2>
       <p className="mb-6 max-w-2xl">
         Welcome to the Tool Shed! Here you’ll find resources, downloads, and custom tools built for Savage Nation USA fans.
       </p>

--- a/src/pages/Videos.jsx
+++ b/src/pages/Videos.jsx
@@ -1,40 +1,29 @@
 import React from "react";
+import { Link } from "react-router-dom";
+import Layout from "../Layout";
 
 export default function Videos() {
   const videoIds = ["YQt8q8VrNbw", "QssmhbtA_g0", "vooONATHNfo"];
   return (
-    <div style={{ background: "#111", minHeight: "100vh", padding: 32 }}>
-      <h2 style={{ color: "white", fontSize: 32, marginBottom: 24 }}>Savage Nation Videos</h2>
-      <div style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
+    <Layout className="text-white" style={{ backgroundImage: "none", backgroundColor: "#111" }}>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-6">Savage Nation Videos</h2>
+      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {videoIds.map(id => (
           <iframe
             key={id}
-            width="360"
-            height="215"
+            className="w-full h-60 sm:h-72 rounded-lg border-4 border-white"
             src={`https://www.youtube.com/embed/${id}`}
             title="Savage Nation Video"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
-            style={{ border: "4px solid #fff", borderRadius: 12 }}
           />
         ))}
       </div>
-      <br />
-      <a href="/landing">
-        <button
-          style={{
-            marginTop: 32,
-            padding: "14px 42px",
-            borderRadius: 8,
-            background: "#eee",
-            fontWeight: "bold",
-            fontSize: 18,
-            border: "none",
-            boxShadow: "2px 4px 14px #0002"
-          }}>
+      <Link to="/landing">
+        <button className="mt-8 px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">
           Back
         </button>
-      </a>
-    </div>
+      </Link>
+    </Layout>
   );
 }

--- a/src/pages/WeeklyBlog.jsx
+++ b/src/pages/WeeklyBlog.jsx
@@ -12,7 +12,7 @@ export default function WeeklyBlog() {
 
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-4xl font-bold mb-4">Weekly Blog</h2>
+      <h2 className="text-3xl sm:text-4xl font-bold mb-4">Weekly Blog</h2>
       <p className="mb-6 max-w-2xl">
         Read the latest updates, stories, and patriotic rants from the Savage Nation USA crew. New blogs drop every week!
       </p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,4 @@
+import typography from '@tailwindcss/typography'
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -7,5 +8,7 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    typography
+  ],
 }


### PR DESCRIPTION
## Summary
- add typography plugin for Tailwind
- wrap pages in responsive container via Layout
- enhance grid and cards for Store
- convert Videos page to Tailwind styles
- improve typography responsiveness across pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866c4fa89848325a8708787ae7403ce