### PR TITLE
Add shared NavBar

### DIFF
--- a/src/Layout.jsx
+++ b/src/Layout.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useAuth } from "./contexts/AuthContext";
+import NavBar from "./NavBar";
 
 export default function Layout({ children, className = "", style = {} }) {
   const { isAuthenticated, logout } = useAuth();
@@ -11,6 +12,7 @@ export default function Layout({ children, className = "", style = {} }) {
       }
       style={{ backgroundImage: "url('/bg.png')", ...style }}
     >
+      <NavBar />
       {isAuthenticated && (
         <div className="absolute top-4 right-4">
           <button

--- a/src/NavBar.jsx
+++ b/src/NavBar.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const links = [
+  { to: "/landing", label: "Home" },
+  { to: "/store", label: "Store" },
+  { to: "/videos", label: "Videos" },
+  { to: "/about", label: "About" },
+  { to: "/contact", label: "Contact" },
+  { to: "/gallery", label: "Gallery" },
+  { to: "/faq", label: "FAQ" },
+  { to: "/story", label: "Story" },
+  { to: "/charities", label: "Charities" },
+  { to: "/mission", label: "Mission" },
+  { to: "/toolshed", label: "Tool Shed" },
+  { to: "/weeklyblog", label: "Weekly Blog" },
+];
+
+export default function NavBar() {
+  return (
+    <nav className="absolute top-0 left-0 w-full bg-black/70 text-white px-4 py-2 flex flex-wrap justify-center gap-4 z-10">
+      {links.map((link) => (
+        <Link key={link.to} to={link.to} className="hover:underline">
+          {link.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 
 export default function About() {
@@ -9,9 +8,6 @@ export default function About() {
       <p className="mb-6 max-w-2xl">
         Savage Nation USA was founded to bring the fiercest, most unapologetic patriotic gear to the world.
       </p>
-      <Link to="/landing">
-        <button className="px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/BlogAdmin.jsx
+++ b/src/pages/BlogAdmin.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 import { loadPosts, savePosts } from "../blogStorage";
 
@@ -97,9 +96,6 @@ export default function BlogAdmin() {
           </li>
         ))}
       </ul>
-      <Link to="/weeklyblog" className="block mt-8">
-        <button className="px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back to Blog</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/Charities.jsx
+++ b/src/pages/Charities.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 
 export default function Charities() {
@@ -11,9 +10,6 @@ export default function Charities() {
         <li>Charity B – Provides tactical gear to first responders.</li>
         <li>Charity C – Funds wilderness rehabilitation programs.</li>
       </ul>
-      <Link to="/landing">
-        <button className="px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 
 export default function Contact() {
@@ -25,9 +24,6 @@ export default function Contact() {
           Send Message
         </button>
       </form>
-      <Link to="/landing">
-        <button className="mt-6 px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/EditBlog.jsx
+++ b/src/pages/EditBlog.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 import { loadPosts, savePosts } from "../blogStorage";
 
@@ -104,9 +103,6 @@ export default function EditBlog() {
           </li>
         ))}
       </ul>
-      <Link to="/weeklyblog" className="block mt-8">
-        <button className="px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back to Blog</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 
 const faqItems = [
@@ -20,9 +19,6 @@ export default function FAQ() {
           </div>
         ))}
       </div>
-      <Link to="/landing">
-        <button className="mt-8 px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 
 const galleryItems = [
@@ -21,9 +20,6 @@ export default function Gallery() {
           </div>
         ))}
       </div>
-      <Link to="/landing">
-        <button className="mt-8 px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/Mission.jsx
+++ b/src/pages/Mission.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 
 export default function Mission() {
@@ -9,9 +8,6 @@ export default function Mission() {
       <p className="mb-6 max-w-2xl">
         [Describe your mission and promise here—what Savage Nation USA stands for, and the guarantees you make to your customers.]
       </p>
-      <Link to="/landing">
-        <button className="px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/Store.jsx
+++ b/src/pages/Store.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 
 const initialProducts = [
@@ -37,11 +36,6 @@ export default function Store() {
           </div>
         ))}
       </div>
-      <Link to="/landing">
-        <button className="mt-8 px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">
-          Back
-        </button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/Story.jsx
+++ b/src/pages/Story.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 
 export default function Story() {
@@ -9,9 +8,6 @@ export default function Story() {
       <p className="mb-6 max-w-2xl">
         [Your brand’s story goes here—how Savage Nation USA came to be, your mission, and your journey.]
       </p>
-      <Link to="/landing">
-        <button className="px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/ToolShed.jsx
+++ b/src/pages/ToolShed.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 
 export default function ToolShed() {
@@ -14,9 +13,6 @@ export default function ToolShed() {
         <li>Utility apps (coming soon!)</li>
         <li>Patriotic printables</li>
       </ul>
-      <Link to="/landing">
-        <button className="px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back</button>
-      </Link>
     </Layout>
   );
 }

--- a/src/pages/Videos.jsx
+++ b/src/pages/Videos.jsx
@@ -20,21 +20,6 @@ export default function Videos() {
         ))}
       </div>
       <br />
-      <a href="/landing">
-        <button
-          style={{
-            marginTop: 32,
-            padding: "14px 42px",
-            borderRadius: 8,
-            background: "#eee",
-            fontWeight: "bold",
-            fontSize: 18,
-            border: "none",
-            boxShadow: "2px 4px 14px #0002"
-          }}>
-          Back
-        </button>
-      </a>
     </div>
   );
 }

--- a/src/pages/WeeklyBlog.jsx
+++ b/src/pages/WeeklyBlog.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import Layout from "../Layout";
 import { loadPosts } from "../blogStorage";
 
@@ -28,9 +27,6 @@ export default function WeeklyBlog() {
           </li>
         ))}
       </ul>
-      <Link to="/landing">
-        <button className="px-6 py-3 bg-gray-300 hover:bg-gray-400 rounded-md">Back</button>
-      </Link>
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- add a site-wide `NavBar` component with links
- render the NavBar inside `Layout.jsx`
- remove page-level "Back" links now that we have global navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866c50214348325b1e1bc0a707789d0