### PR TITLE
refactor layout spacing and colors

### DIFF
--- a/src/Layout.jsx
+++ b/src/Layout.jsx
@@ -22,7 +22,7 @@ export default function Layout({ className = "", style = {} }) {
           </button>
         </div>
       )}
-      <main className="flex-grow container mx-auto w-full p-4 sm:p-8 mt-16">
+      <main className="flex-grow container mx-auto w-full p-8 sm:p-16 mt-20">
         <Outlet />
       </main>
       <Footer />

--- a/src/components/Comments.jsx
+++ b/src/components/Comments.jsx
@@ -30,7 +30,7 @@ export default function Comments({ postId }) {
     <div className="mt-2">
       <ul className="space-y-1">
         {comments.map(c => (
-          <li key={c.id} className="border p-1 rounded">
+          <li key={c.id} className="border border-gray-300 p-1 rounded">
             {c.text}
           </li>
         ))}
@@ -38,7 +38,7 @@ export default function Comments({ postId }) {
       {isAuthenticated && (
         <form onSubmit={submit} className="mt-2 flex space-x-2">
           <input
-            className="border p-1 flex-1 rounded"
+            className="border border-gray-300 p-1 flex-1 rounded"
             value={text}
             onChange={e => setText(e.target.value)}
           />

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --color-primary: #1e3a8a;
+  --color-secondary: #dc2626;
+  --color-accent: #fbbf24;
+  --color-background: #f9fafb;
+}
+
+body {
+  background-color: var(--color-background);
+}
+
 .page-bg {
   background-image: url('/bg.png');
   background-size: cover;

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -21,11 +21,11 @@ const galleryItems = [
 
 export default function Gallery() {
   return (
-    <Layout className="p-8 text-black">
+    <Layout className="p-12 text-black">
       <h2 className="text-3xl sm:text-4xl font-bold mb-6">Gallery</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
         {galleryItems.map((item, i) => (
-          <div key={i} className="border rounded-lg p-4 shadow">
+          <div key={i} className="rounded-lg p-8">
             <img
               src={item.src}
               alt={item.alt}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 export default function Home() {
   return (
     <div
-      className="relative min-h-screen flex flex-col items-center justify-center bg-cover bg-center text-white"
+      className="relative min-h-screen flex flex-col items-center justify-center bg-cover bg-center text-white p-8 sm:p-16"
       style={{ backgroundImage: "url('/bg.png')" }}
     >
       <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-center">
@@ -17,7 +17,10 @@ export default function Home() {
         ONLY ENTER IF YOU&apos;RE SAVAGE ENOUGH
       </p>
       <Link to="/landing">
-        <button className="mt-6 px-8 py-4 bg-gradient-to-r from-blue-600 via-white to-red-600 text-white font-bold rounded-full shadow-lg ring-2 ring-white transition-transform hover:scale-105">
+        <button
+          className="mt-6 px-8 py-4 font-bold rounded-full transition-transform hover:scale-105"
+          style={{ backgroundColor: "var(--color-primary)" }}
+        >
           Enter Here
         </button>
       </Link>

--- a/src/pages/Store.jsx
+++ b/src/pages/Store.jsx
@@ -19,18 +19,18 @@ export default function Store() {
     p.name.toLowerCase().includes(searchTerm.toLowerCase())
   );
   return (
-    <Layout className="p-8 text-black">
+    <Layout className="p-12 text-black">
       <h2 className="text-3xl sm:text-4xl font-bold mb-4">Our Store</h2>
       <input
-        className="mb-6 px-4 py-2 border rounded w-full max-w-md placeholder-black/50"
+        className="mb-6 px-4 py-2 border border-gray-300 rounded w-full max-w-md placeholder-black/50"
         type="text"
         placeholder="Search products..."
         value={searchTerm}
         onChange={e => setSearchTerm(e.target.value)}
       />
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
         {filtered.map(item => (
-          <div key={item.id} className="bg-white border rounded-lg p-4 shadow-lg flex flex-col">
+          <div key={item.id} className="bg-white rounded-lg p-6 flex flex-col">
             <div className="h-40 bg-gray-200 mb-4 flex items-center justify-center">
               <span className="text-gray-500">Image</span>
             </div>

--- a/src/pages/Videos.jsx
+++ b/src/pages/Videos.jsx
@@ -5,13 +5,13 @@ import Layout from "../Layout";
 export default function Videos() {
   const videoIds = ["YQt8q8VrNbw", "QssmhbtA_g0", "vooONATHNfo"];
   return (
-    <Layout className="p-8 sm:p-12 text-white bg-[#111] bg-none">
+    <Layout className="p-12 sm:p-16 text-white bg-[#111] bg-none">
       <h2 className="text-3xl sm:text-4xl font-bold mb-6">Savage Nation Videos</h2>
-      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {videoIds.map(id => (
           <iframe
             key={id}
-            className="w-full h-60 sm:h-72 rounded-lg border-4 border-white"
+            className="w-full h-60 sm:h-72 rounded-lg border border-gray-600"
             src={`https://www.youtube.com/embed/${id}`}
             title="Savage Nation Video"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
## Summary
- define CSS variables for primary, secondary, accent, and background colors
- add generous padding/margin to layout containers
- remove visual noise from buttons, cards, and embeds

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897adabedc88325888122da0b30bbb3