### PR TITLE
Add scroll/hover animations with reduced motion support

### DIFF
--- a/src/components/FadeInSection.jsx
+++ b/src/components/FadeInSection.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef, useState } from "react";
+
+export default function FadeInSection({ children, className = "" }) {
+  const ref = useRef(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(true);
+            observer.disconnect();
+          }
+        });
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  const classes = [
+    "opacity-0 translate-y-4",
+    "motion-reduce:opacity-100 motion-reduce:translate-y-0 motion-reduce:transition-none motion-reduce:animate-none",
+    isVisible ? "motion-safe:animate-fade-slide" : "",
+    className,
+  ].join(" ");
+
+  return (
+    <div ref={ref} className={classes}>
+      {children}
+    </div>
+  );
+}

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import Layout from "../Layout";
+import FadeInSection from "../components/FadeInSection";
 
 const galleryItems = [
   {
@@ -22,16 +23,20 @@ const galleryItems = [
 export default function Gallery() {
   return (
     <Layout className="p-8 text-black">
-      <h2 className="text-3xl sm:text-4xl font-bold mb-6">Gallery</h2>
+      <FadeInSection>
+        <h2 className="text-3xl sm:text-4xl font-bold mb-6">Gallery</h2>
+      </FadeInSection>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {galleryItems.map((item, i) => (
-          <div key={i} className="border rounded-lg p-4 shadow">
-            <img
-              src={item.src}
-              alt={item.alt}
-              className="object-cover w-full h-40 mb-4 rounded"
-            />
-          </div>
+          <FadeInSection key={i}>
+            <div className="border rounded-lg p-4 shadow">
+              <img
+                src={item.src}
+                alt={item.alt}
+                className="object-cover w-full h-40 mb-4 rounded"
+              />
+            </div>
+          </FadeInSection>
         ))}
       </div>
       <Link to="/landing">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import FadeInSection from "../components/FadeInSection";
 
 export default function Home() {
   return (
@@ -7,20 +8,22 @@ export default function Home() {
       className="relative min-h-screen flex flex-col items-center justify-center bg-cover bg-center text-white"
       style={{ backgroundImage: "url('/bg.png')" }}
     >
-      <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-center">
-        Savage Nation USA
-      </h1>
-      <p className="mt-.5 text-center text-blue-200">
-        Proudly supporting our Veterans
-      </p>
-      <p className="mt-4 text-base sm:text-lg font-semibold text-red-500 uppercase text-center">
-        ONLY ENTER IF YOU&apos;RE SAVAGE ENOUGH
-      </p>
-      <Link to="/landing">
-        <button className="mt-6 px-8 py-4 bg-gradient-to-r from-blue-600 via-white to-red-600 text-white font-bold rounded-full shadow-lg ring-2 ring-white transition-transform hover:scale-105">
-          Enter Here
-        </button>
-      </Link>
+      <FadeInSection className="flex flex-col items-center">
+        <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-center">
+          Savage Nation USA
+        </h1>
+        <p className="mt-.5 text-center text-blue-200">
+          Proudly supporting our Veterans
+        </p>
+        <p className="mt-4 text-base sm:text-lg font-semibold text-red-500 uppercase text-center">
+          ONLY ENTER IF YOU&apos;RE SAVAGE ENOUGH
+        </p>
+        <Link to="/landing">
+          <button className="mt-6 px-8 py-4 bg-gradient-to-r from-blue-600 via-white to-red-600 text-white font-bold rounded-full shadow-lg ring-2 ring-white transition-transform hover:scale-105">
+            Enter Here
+          </button>
+        </Link>
+      </FadeInSection>
     </div>
   );
 }

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ShoppingCart } from "lucide-react";
+import FadeInSection from "../components/FadeInSection";
 
 const pages = [
   { key: "store",      label: "Store",      icon: ShoppingCart },
@@ -22,28 +23,32 @@ export default function Landing() {
 
   return (
     <div className="min-h-screen flex flex-col sm:flex-row bg-[url('/bg.png')] bg-cover bg-center text-white">
-      <aside className="w-full sm:w-64 bg-black bg-opacity-70 p-6">
-        <h3 className="text-xl sm:text-2xl font-bold mb-4">Navigation</h3>
-        <nav className="flex flex-col space-y-2">
-          {pages.map((p) => {
-            const key = typeof p === "object" ? p.key : p;
-            const label = typeof p === "object" ? p.label : p.charAt(0).toUpperCase()+p.slice(1);
-            const Icon  = typeof p === "object" ? p.icon : null;
-            return (
-              <button
-                key={key}
-                onClick={() => handleNav(key)}
-                className="flex items-center px-4 py-2 hover:bg-white/20 rounded transition"
-              >
-                {Icon && <Icon className="w-5 h-5 mr-2" />}
-                {label}
-              </button>
-            );
-          })}
-        </nav>
-      </aside>
+      <FadeInSection className="w-full sm:w-64">
+        <aside className="w-full bg-black bg-opacity-70 p-6">
+          <h3 className="text-xl sm:text-2xl font-bold mb-4">Navigation</h3>
+          <nav className="flex flex-col space-y-2">
+            {pages.map((p) => {
+              const key = typeof p === "object" ? p.key : p;
+              const label = typeof p === "object" ? p.label : p.charAt(0).toUpperCase()+p.slice(1);
+              const Icon  = typeof p === "object" ? p.icon : null;
+              return (
+                <button
+                  key={key}
+                  onClick={() => handleNav(key)}
+                  className="flex items-center px-4 py-2 rounded transition-all duration-300 hover:bg-white/20 hover:translate-x-1 hover:opacity-90 motion-reduce:transition-none motion-reduce:transform-none"
+                >
+                  {Icon && <Icon className="w-5 h-5 mr-2" />}
+                  {label}
+                </button>
+              );
+            })}
+          </nav>
+        </aside>
+      </FadeInSection>
       <main className="flex-1 p-6 sm:p-10 overflow-y-auto">
-        <h2 className="text-3xl sm:text-4xl font-bold mb-6 text-white">Welcome to Savage Nation USA</h2>
+        <FadeInSection>
+          <h2 className="text-3xl sm:text-4xl font-bold mb-6 text-white">Welcome to Savage Nation USA</h2>
+        </FadeInSection>
         <input
           type="text"
           placeholder="Search pages..."

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,17 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        'fade-slide': {
+          '0%': { opacity: '0', transform: 'translateY(1rem)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' }
+        }
+      },
+      animation: {
+        'fade-slide': 'fade-slide 300ms ease-out forwards'
+      }
+    },
   },
   plugins: [
     typography


### PR DESCRIPTION
## Summary
- add Tailwind keyframes for a 300ms fade-slide animation
- introduce reusable `FadeInSection` component leveraging IntersectionObserver
- animate home, gallery, and landing content on scroll with hover slide transitions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897adb05b288325bbed94de08fec034