### PR TITLE
Fix missing Hero image by referencing public bg.png

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import heroImage from '../assets/hero.webp';
+
+// Use a background image from the public directory since hero.webp is missing
+const heroImage = '/bg.png';
 
 const Hero = () => {
   return (


### PR DESCRIPTION
## Summary
- Use `/bg.png` from the public folder in Hero component instead of missing `hero.webp`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689814e44e44832597371011b0562278